### PR TITLE
Fix for Swift Package Manager Release

### DIFF
--- a/BoxPreviewSDK.podspec
+++ b/BoxPreviewSDK.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.social_media_url   = "https://twitter.com/box"
   spec.ios.deployment_target = "11.0"
   spec.source       = { :git => "https://github.com/box/box-ios-preview-sdk.git", :tag => "v"+spec.version.to_s }
-  spec.swift_version = ["5.0", "5.1"]
+  spec.swift_versions = ["5.0", "5.1"]
   spec.requires_arc = true
   spec.dependency "BoxSDK", "~> 3.0.0"
 

--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BoxPreviewSDKTests",
-            dependencies: ["BoxPreviewSDK"],
-            path: "Tests"
+            dependencies: ["BoxPreviewSDK"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/box/box-swift-sdk.git", .upToNextMajor(from: "3.0.0"))
+        .package(url: "https://github.com/box/box-ios-sdk.git", .upToNextMajor(from: "3.0.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,6 @@ let package = Package(
             name: "BoxPreviewSDK",
             dependencies: [],
             path: "Sources"
-        ),
-        .testTarget(
-            name: "BoxPreviewSDKTests",
-            dependencies: ["BoxPreviewSDK"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     targets: [
         .target(
             name: "BoxPreviewSDK",
-            dependencies: [],
+            dependencies: ["BoxSDK"],
             path: "Sources"
         )
     ]


### PR DESCRIPTION
### Goals :soccer:
- Have Cocoapods distribution support Swift 5.1

### Implementation Details :construction:
- Updated podspec

### Testing Details :mag:
- No Testing
