### PR TITLE
Remove refresh button

### DIFF
--- a/BoxPreviewSampleApp/ViewControllers/ViewController.swift
+++ b/BoxPreviewSampleApp/ViewControllers/ViewController.swift
@@ -105,7 +105,7 @@ private extension ViewController {
                             DispatchQueue.main.async {
                                 self.folderItems.append(item)
                                 self.tableView.reloadData()
-                                self.navigationItem.rightBarButtonItem?.title = "Refresh"
+                                self.navigationItem.rightBarButtonItem = nil
                             }
                         case let .failure(error):
                             print ("     No Item #\(String(format: "%03d", i)) | \(error.message)")

--- a/SampleApps/JWTSampleApp/Cartfile.resolved
+++ b/SampleApps/JWTSampleApp/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/box/box-ios-preview-sdk/limited-beta-release/boxPreviewSDK.json" "3.0.0-rc.2"
-binary "https://raw.githubusercontent.com/box/box-ios-sdk/limited-beta-release/boxSDK.json" "3.0.0-rc.2"
+github "box/box-ios-preview-sdk" "v3.0.0"
+github "box/box-ios-sdk" "v3.0.0"

--- a/SampleApps/JWTSampleApp/JWTSampleApp/ViewControllers/ViewController.swift
+++ b/SampleApps/JWTSampleApp/JWTSampleApp/ViewControllers/ViewController.swift
@@ -187,7 +187,7 @@ private extension ViewController {
                             DispatchQueue.main.async {
                                 self.folderItems.append(item)
                                 self.tableView.reloadData()
-                                self.navigationItem.rightBarButtonItem?.title = "Refresh"
+                                self.navigationItem.rightBarButtonItem = nil
                             }
                         case let .failure(error):
                             print ("     No Item #\(String(format: "%03d", i)) | \(error.message)")

--- a/SampleApps/OAuth2SampleApp/Cartfile.resolved
+++ b/SampleApps/OAuth2SampleApp/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/box/box-ios-preview-sdk/limited-beta-release/boxPreviewSDK.json" "3.0.0-rc.2"
-binary "https://raw.githubusercontent.com/box/box-ios-sdk/limited-beta-release/boxSDK.json" "3.0.0-rc.2"
+github "box/box-ios-preview-sdk" "v3.0.0"
+github "box/box-ios-sdk" "v3.0.0"

--- a/SampleApps/OAuth2SampleApp/OAuth2SampleApp/ViewControllers/ViewController.swift
+++ b/SampleApps/OAuth2SampleApp/OAuth2SampleApp/ViewControllers/ViewController.swift
@@ -188,7 +188,7 @@ private extension ViewController {
                             DispatchQueue.main.async {
                                 self.folderItems.append(item)
                                 self.tableView.reloadData()
-                                self.navigationItem.rightBarButtonItem?.title = "Refresh"
+                                self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Log out", style: .plain, target: self, action: #selector(self.logoutPressed))
                             }
                         case let .failure(error):
                             print ("     No Item #\(String(format: "%03d", i)) | \(error.message)")


### PR DESCRIPTION
### Issue Link :link:
- https://jira.inside-box.net/browse/SDK-1201

### Goals :soccer:
- Fix refresh button for all sample apps. Currently, refresh button is logging out when pressed

### Implementation Details :construction:
- Removed refresh button and replaced it with logout button
- Currently have pull down to refresh, so no need to have it
- Also, refresh button was taking the place of the logout at times and it is essential to always have a logout button

### Testing Details :mag:
- Manual testing of apps