### PR TITLE
Fix button to exit from search results

### DIFF
--- a/BoxPreviewSampleApp/ViewControllers/ViewController.swift
+++ b/BoxPreviewSampleApp/ViewControllers/ViewController.swift
@@ -29,9 +29,9 @@ class ViewController: UITableViewController {
         super.viewDidLoad()
         title = "Box Preview SDK - Sample App"
         setupView()
-        contentSDK = BoxSDK(clientId: "w8j8xjpheut2i5bn6mj7ois9qdlznk85", clientSecret: "NqBbzIK9akWndtgdnkUaLQgleK6208iZ")
-//        #error("Obtain a Developer Token for your app in the Box Developer Console at https://app.box.com/developers/console")
-        client = contentSDK.getClient(token: "8c6ddw96WdZXoqyhjizbTi6u1MM7BVae")
+        contentSDK = BoxSDK(clientId: "", clientSecret: "")
+        #error("Obtain a Developer Token for your app in the Box Developer Console at https://app.box.com/developers/console")
+        client = contentSDK.getClient(token: "")
         previewSDK = BoxPreviewSDK(client: client)
         getSinglePageOfFolderItems()
     }

--- a/BoxPreviewSampleApp/ViewControllers/ViewController.swift
+++ b/BoxPreviewSampleApp/ViewControllers/ViewController.swift
@@ -29,9 +29,9 @@ class ViewController: UITableViewController {
         super.viewDidLoad()
         title = "Box Preview SDK - Sample App"
         setupView()
-        contentSDK = BoxSDK(clientId: "", clientSecret: "")
-        #error("Obtain a Developer Token for your app in the Box Developer Console at https://app.box.com/developers/console")
-        client = contentSDK.getClient(token: "")
+        contentSDK = BoxSDK(clientId: "w8j8xjpheut2i5bn6mj7ois9qdlznk85", clientSecret: "NqBbzIK9akWndtgdnkUaLQgleK6208iZ")
+//        #error("Obtain a Developer Token for your app in the Box Developer Console at https://app.box.com/developers/console")
+        client = contentSDK.getClient(token: "8c6ddw96WdZXoqyhjizbTi6u1MM7BVae")
         previewSDK = BoxPreviewSDK(client: client)
         getSinglePageOfFolderItems()
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## v3.0.1 [2019-12-11]
+
+__Breaking Changes:__
+
+__New Features and Enhancements:__
+
+- Back button for search results exits out of search view, allowing the user to view the file instead of exiting to folder items table view 
+
+
 ## v3.0.0 [2019-11-18]
 
 __Breaking Changes:__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## v3.0.1 [2019-12-11]
+## In Progress
 
 __Breaking Changes:__
 

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -437,17 +437,6 @@ extension PDFViewController {
         hideSearchResultsView()
         navigationController?.present(navigationViewController, animated: true, completion: nil)
     }
-    
-    @objc private func backTapped() {
-        if !currentSearchResults.isEmpty {
-            removeHighlightFromSearchResults()
-            hideSearchResultsView()
-            currentSearchResults = []
-        }
-        else {
-            navigationController?.popViewController(animated: true)
-        }
-    }
 }
 
 // MARK: - ThumbnailGridViewControllerDelegate

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -200,7 +200,7 @@ private extension PDFViewController {
         setupTitleView()
         setupNavigationItems()
         setupGestureRecognizers()
-        setupSearchResultsNavitionView()
+        setupSearchResultsNavigationView()
         setupObservers()
         loadPDF()
         updatePageIndicator()
@@ -255,7 +255,8 @@ private extension PDFViewController {
         navBarItems.append(search)
         
         parent?.navigationItem.rightBarButtonItems = navBarItems
-        parent?.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        let backButton = UIBarButtonItem(title: "back", style: .plain, target: self, action: #selector(backTapped))
+        parent?.navigationItem.leftBarButtonItem = backButton
     }
     
     func setupObservers() {
@@ -287,7 +288,7 @@ private extension PDFViewController {
         pdfView.addGestureRecognizer(swipeRight)
     }
     
-    func setupSearchResultsNavitionView() {
+    func setupSearchResultsNavigationView() {
         view.addSubview(searchResultsNavigationView)
         NSLayoutConstraint.activate([
             searchResultsNavigationView.heightAnchor.constraint(equalToConstant: 44),
@@ -436,6 +437,17 @@ extension PDFViewController {
         removeHighlightFromSearchResults()
         hideSearchResultsView()
         navigationController?.present(navigationViewController, animated: true, completion: nil)
+    }
+    
+    @objc private func backTapped() {
+        if !currentSearchResults.isEmpty {
+            removeHighlightFromSearchResults()
+            hideSearchResultsView()
+            currentSearchResults = []
+        }
+        else {
+            navigationController?.popViewController(animated: true)
+        }
     }
 }
 

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -255,8 +255,7 @@ private extension PDFViewController {
         navBarItems.append(search)
         
         parent?.navigationItem.rightBarButtonItems = navBarItems
-        let backButton = UIBarButtonItem(title: "back", style: .plain, target: self, action: #selector(backTapped))
-        parent?.navigationItem.leftBarButtonItem = backButton
+        parent?.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
     
     func setupObservers() {
@@ -480,6 +479,14 @@ extension PDFViewController: SearchViewControllerDelegate {
         hightlightCurrentSearchResult(selection)
         configureSearchResultsView(selection: selection, searchResults: searchResults)
         showSearchResultsView()
+        parent?.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.stop, target: self, action: #selector(closeSearchView))
+    }
+    
+    @objc private func closeSearchView() {
+        removeHighlightFromSearchResults()
+        hideSearchResultsView()
+        currentSearchResults = []
+        parent?.navigationItem.leftBarButtonItem = nil
     }
     
     private func highlightSearchResults(selections: [PDFSelection]) {


### PR DESCRIPTION
### Issue Link :link:
- https://jira.inside-box.net/browse/SDK-1184

### Goals :soccer:
- Fix button that exits from search results. Back button for search results was previously exiting to files table view instead of exiting out of search view and still allowing the user to view the file.

### Implementation Details :construction:
- Replaced backBarButton with leftBarButton in the search results view to allow for specifying a custom action
- Custom action exits out of search view

### Testing Details :mag:
- Manual testing
