### PR TITLE
Fix for double tap zoom for PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 - Back button for search results exits out of search view, allowing the user to view the file instead of exiting to folder items table view 
-- Fixed single tap full screen mode on PDFs
+- Fixed single tap for full screen mode toggle on PDFs
 - Fixed double tap zoom level on PDFs
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 Changelog
 =========
 
-## In Progress
+## Next Release
 
 __Breaking Changes:__
 
 __New Features and Enhancements:__
 
 - Back button for search results exits out of search view, allowing the user to view the file instead of exiting to folder items table view 
+- Fixed single tap full screen mode on PDFs
+- Fixed double tap zoom on PDFs
 
 
 ## v3.0.0 [2019-11-18]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ __New Features and Enhancements:__
 
 - Back button for search results exits out of search view, allowing the user to view the file instead of exiting to folder items table view 
 - Fixed single tap full screen mode on PDFs
-- Fixed double tap zoom on PDFs
+- Fixed double tap zoom level on PDFs
 
 
 ## v3.0.0 [2019-11-18]

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -194,7 +194,6 @@ private extension PDFViewController {
     func setupView() {
         view.addSubview(pdfView)
         view.addSubview(pdfThumbnailContainerView)
-        view.addGestureRecognizer(singleTapGesture)
         setupPDFView()
         setupThumbnailView()
         setupTitleView()
@@ -276,8 +275,8 @@ private extension PDFViewController {
     }
     
     func setupGestureRecognizers() {
-        view.addGestureRecognizer(singleTapGesture)
-        view.addGestureRecognizer(doubleTapGesture)
+        pdfView.addGestureRecognizer(singleTapGesture)
+        pdfView.addGestureRecognizer(doubleTapGesture)
         let swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture))
         swipeLeft.direction = .left
         pdfView.addGestureRecognizer(swipeLeft)
@@ -567,6 +566,7 @@ extension PDFViewController: UIGestureRecognizerDelegate {
 
 extension PDFViewController {
     @objc func doubleTapped(_ sender: UITapGestureRecognizer) {
+        NSLog("test")
         guard let scrollView = pdfView.subviews.first as? UIScrollView, let currentPage = pdfView.currentPage else {
             return
         }

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -566,7 +566,6 @@ extension PDFViewController: UIGestureRecognizerDelegate {
 
 extension PDFViewController {
     @objc func doubleTapped(_ sender: UITapGestureRecognizer) {
-        NSLog("test")
         guard let scrollView = pdfView.subviews.first as? UIScrollView, let currentPage = pdfView.currentPage else {
             return
         }


### PR DESCRIPTION
### Issue Link :link:
- https://jira.inside-box.net/browse/SDK-1183

### Goals :soccer:
- Fix single tap full screen mode on PDFs
- Fix double tap zoom on PDFs

### Implementation Details :construction:
- Added custom gestures to `pdfView` and removed them from `view`

### Testing Details :mag:
- Manual testing
