### PR TITLE
Fixed alerts and share sheets for iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ __New Features and Enhancements:__
 
 __Bug Fixes:__
 
-- Fixed error for alerts and share sheets on the iPad.
+- Fixed error for alerts and share sheets on the iPad (#92).
 
 
 ## v3.2.0 [2020-02-13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ __New Features and Enhancements:__
 
 __Bug Fixes:__
 
-- Fixed error for alerts and share sheets on the iPad (#92).
+- Fixed error for alerts and share sheets on the iPad ([#92](https://github.com/box/box-ios-preview-sdk/pull/92))
 
 
 ## v3.2.0 [2020-02-13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ __New Features and Enhancements:__
 
 __Bug Fixes:__
 
-- Fixed error for alerts and share sheets on the iPad ([#92](https://github.com/box/box-ios-preview-sdk/pull/92))
+- Fixed bug with Alerts and Share Sheets on the iPad ([#92](https://github.com/box/box-ios-preview-sdk/pull/92))
 
 
 ## v3.2.0 [2020-02-13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## Next Release
+
+__Breaking Changes:__
+
+__New Features and Enhancements:__
+
+__Bug Fixes:__
+
+- Fixed error for alerts and share sheets on the iPad.
+
+
 ## v3.2.0 [2020-02-13]
 
 __Breaking Changes:__

--- a/Sources/Core/Extensions/UIViewController+Alert.swift
+++ b/Sources/Core/Extensions/UIViewController+Alert.swift
@@ -14,6 +14,9 @@ extension UIViewController {
         let closeAction = UIAlertAction(title: "OK", style: .default) { _ in
             alert.dismiss(animated: true, completion: nil)
         }
+        alert.popoverPresentationController?.sourceRect = self.view.bounds
+        alert.popoverPresentationController?.sourceView = self.view
+        alert.popoverPresentationController?.permittedArrowDirections = []
         alert.addAction(closeAction)
         present(alert, animated: true, completion: nil)
     }

--- a/Sources/Core/UI/PreviewItemChildViewController.swift
+++ b/Sources/Core/UI/PreviewItemChildViewController.swift
@@ -134,7 +134,7 @@ extension PreviewItemChildViewController {
         let activityController: UIActivityViewController = UIActivityViewController(activityItems: [filePath], applicationActivities: nil)
         activityController.popoverPresentationController?.sourceRect = self.view.bounds
         activityController.popoverPresentationController?.sourceView = self.view
-        activityController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
+        activityController.popoverPresentationController?.permittedArrowDirections = []
         present(activityController, animated: true, completion: nil)
     }
 }

--- a/Sources/Core/UI/PreviewItemChildViewController.swift
+++ b/Sources/Core/UI/PreviewItemChildViewController.swift
@@ -120,6 +120,9 @@ extension PreviewItemChildViewController {
         try? itemData?.write(to: path)
 
         let activityController: UIActivityViewController = UIActivityViewController(activityItems: [path], applicationActivities: nil)
+        activityController.popoverPresentationController?.sourceRect = self.view.bounds
+        activityController.popoverPresentationController?.sourceView = self.view
+        activityController.popoverPresentationController?.permittedArrowDirections = []
         present(activityController, animated: true, completion: nil)
     }
     
@@ -129,6 +132,9 @@ extension PreviewItemChildViewController {
     ///   - filePath: URL of the file path to the downloaded file
     func displayAllShareOptions(filePath: URL) {
         let activityController: UIActivityViewController = UIActivityViewController(activityItems: [filePath], applicationActivities: nil)
+        activityController.popoverPresentationController?.sourceRect = self.view.bounds
+        activityController.popoverPresentationController?.sourceView = self.view
+        activityController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
         present(activityController, animated: true, completion: nil)
     }
 }

--- a/Sources/Core/UI/Viewers/Image/ImageViewController.swift
+++ b/Sources/Core/UI/Viewers/Image/ImageViewController.swift
@@ -226,6 +226,7 @@ private extension ImageViewController {
             button.action = #selector(shareOptionsButtonTapped(_:))
             buttons.append(button)
             toolbarButtons = buttons
+            showAlertWith(title: "Error", message: "Was not able to save the image due to missing data.")
             return
         }
 

--- a/Sources/Core/UI/Viewers/Image/ImageViewController.swift
+++ b/Sources/Core/UI/Viewers/Image/ImageViewController.swift
@@ -226,7 +226,6 @@ private extension ImageViewController {
             button.action = #selector(shareOptionsButtonTapped(_:))
             buttons.append(button)
             toolbarButtons = buttons
-            showAlertWith(title: "Error", message: "Was not able to save the image due to missing data.")
             return
         }
 


### PR DESCRIPTION
### Goals :soccer:
- Fix error that arises when an alert is shown on the iPad
- Fix error that arises when a share sheet is shown on the iPad

### Implementation Details :construction:
- Both the share sheet (UIActivityViewController) and alerts (UIAlertController) require anchor points for the iPad that can either be a button or the view itself. Both items are now anchored to the view. Also, their arrow directions are set to none, so they will not to try to anchor to a button and throw an error. 

### Testing Details :mag:
- Manual testing
