### PR TITLE
Fix bug where invalid links in a PDF crash the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 __Breaking Changes:__
 
 __New Features and Enhancements:__
+- Add the ability to have mail, facetime, etc. links open in the appropriate apps ([#93](https://github.com/box/box-ios-preview-sdk/pull/93))
 
 __Bug Fixes:__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ __New Features and Enhancements:__
 __Bug Fixes:__
 
 - Fixed bug with Alerts and Share Sheets on the iPad ([#92](https://github.com/box/box-ios-preview-sdk/pull/92))
-- Fixed bug where URLs without schemes in a PDF would crash the app when clicked
+- Fixed bug where URLs without schemes in a PDF would crash the app when clicked ([#93](https://github.com/box/box-ios-preview-sdk/pull/93))
 
 
 ## v3.2.0 [2020-02-13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __New Features and Enhancements:__
 __Bug Fixes:__
 
 - Fixed bug with Alerts and Share Sheets on the iPad ([#92](https://github.com/box/box-ios-preview-sdk/pull/92))
+- Fixed bug where URLs without schemes in a PDF would crash the app when clicked
 
 
 ## v3.2.0 [2020-02-13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 __Breaking Changes:__
 
 __New Features and Enhancements:__
-- Add the ability to have mail, facetime, etc. links open in the appropriate apps ([#93](https://github.com/box/box-ios-preview-sdk/pull/93))
+- Add the ability to have `mailto`, `tel`, etc. links open in the appropriate apps ([#93](https://github.com/box/box-ios-preview-sdk/pull/93))
 
 __Bug Fixes:__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 __Breaking Changes:__
 
 __New Features and Enhancements:__
+
 - Add the ability to have `mailto`, `tel`, etc. links open in the appropriate apps ([#93](https://github.com/box/box-ios-preview-sdk/pull/93))
 
 __Bug Fixes:__

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -67,7 +67,6 @@ public class PDFViewController: UIViewController, PreviewItemChildViewController
         pdfView.delegate = self
         pdfView.displayMode = .singlePage
         pdfView.backgroundColor = pdfBackgroundColor
-        pdfView.enableDataDetectors = true
         pdfView.autoScales = true
         pdfView.displayDirection = .vertical
         if let scrollView = pdfView.subviews.first as? UIScrollView {

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -536,17 +536,12 @@ extension PDFViewController: SearchViewControllerDelegate {
 
 extension PDFViewController: PDFViewDelegate {
     public func pdfViewWillClick(onLink _: PDFView, with url: URL) {
-        var URLCopy = url
-        if URLCopy.scheme == nil {
-            let URLCopyString = "https://" + URLCopy.absoluteString
-            URLCopy = URL(string: URLCopyString)!
-        }
-        if UIApplication.shared.canOpenURL(URLCopy) {
-            let safaryVC = SFSafariViewController(url: URLCopy)
+        if let scheme = url.scheme, (scheme == "https" || scheme == "http") {
+            let safaryVC = SFSafariViewController(url: url)
             present(safaryVC, animated: true, completion: nil)
         } else {
             DispatchQueue.main.async {
-                self.showAlertWith(title: "Error", message: URLCopy.absoluteString + " is an invalid link.")
+                self.showAlertWith(title: "Error", message: url.absoluteString + " is an invalid link. Must have http or https.")
             }
         }
     }

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -67,6 +67,7 @@ public class PDFViewController: UIViewController, PreviewItemChildViewController
         pdfView.delegate = self
         pdfView.displayMode = .singlePage
         pdfView.backgroundColor = pdfBackgroundColor
+        pdfView.enableDataDetectors = true
         pdfView.autoScales = true
         pdfView.displayDirection = .vertical
         if let scrollView = pdfView.subviews.first as? UIScrollView {
@@ -535,8 +536,19 @@ extension PDFViewController: SearchViewControllerDelegate {
 
 extension PDFViewController: PDFViewDelegate {
     public func pdfViewWillClick(onLink _: PDFView, with url: URL) {
-        let safaryVC = SFSafariViewController(url: url)
-        present(safaryVC, animated: true, completion: nil)
+        var URLCopy = url
+        if URLCopy.scheme == nil {
+            let URLCopyString = "https://" + URLCopy.absoluteString
+            URLCopy = URL(string: URLCopyString)!
+        }
+        if UIApplication.shared.canOpenURL(URLCopy) {
+            let safaryVC = SFSafariViewController(url: URLCopy)
+            present(safaryVC, animated: true, completion: nil)
+        } else {
+            DispatchQueue.main.async {
+                self.showAlertWith(title: "Error", message: URLCopy.absoluteString + " is an invalid link.")
+            }
+        }
     }
 }
 

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -536,12 +536,21 @@ extension PDFViewController: SearchViewControllerDelegate {
 
 extension PDFViewController: PDFViewDelegate {
     public func pdfViewWillClick(onLink _: PDFView, with url: URL) {
-        if let scheme = url.scheme, (scheme == "https" || scheme == "http") {
-            let safaryVC = SFSafariViewController(url: url)
+        var URLCopy = url
+        if URLCopy.scheme == nil {
+            let URLCopyString = "https://" + URLCopy.absoluteString
+            URLCopy = URL(string: URLCopyString)!
+        }
+        if let scheme = URLCopy.scheme, (scheme == "https" || scheme == "http") {
+            let safaryVC = SFSafariViewController(url: URLCopy)
             present(safaryVC, animated: true, completion: nil)
         } else {
-            DispatchQueue.main.async {
-                self.showAlertWith(title: "Error", message: url.absoluteString + " is an invalid link. Must have http or https.")
+            UIApplication.shared.open(URLCopy) { (result) in
+                if !result {
+                    DispatchQueue.main.async {
+                        self.showAlertWith(title: "Error", message: url.absoluteString + " is an invalid link that can't be handled by any application.")
+                    }
+                }
             }
         }
     }

--- a/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
+++ b/Sources/Core/UI/Viewers/PDF/PDFViewController.swift
@@ -535,16 +535,15 @@ extension PDFViewController: SearchViewControllerDelegate {
 
 extension PDFViewController: PDFViewDelegate {
     public func pdfViewWillClick(onLink _: PDFView, with url: URL) {
-        var URLCopy = url
-        if URLCopy.scheme == nil {
-            let URLCopyString = "https://" + URLCopy.absoluteString
-            URLCopy = URL(string: URLCopyString)!
+        var finalURL = url
+        if finalURL.scheme == nil {
+            finalURL = URL(string: "https://" + finalURL.absoluteString)!
         }
-        if let scheme = URLCopy.scheme, (scheme == "https" || scheme == "http") {
-            let safaryVC = SFSafariViewController(url: URLCopy)
+        if let scheme = finalURL.scheme, ["http", "https"].contains(scheme) {
+            let safaryVC = SFSafariViewController(url: finalURL)
             present(safaryVC, animated: true, completion: nil)
         } else {
-            UIApplication.shared.open(URLCopy) { (result) in
+            UIApplication.shared.open(finalURL) { (result) in
                 if !result {
                     DispatchQueue.main.async {
                         self.showAlertWith(title: "Error", message: url.absoluteString + " is an invalid link that can't be handled by any application.")


### PR DESCRIPTION
### Goals :soccer:
- Fix a bug where invalid links in a PDF are crashing the app when clicked
- Open links with schemes other than `http` and `https` like `mailto`, `tel`, `sms`, etc. in the appropriate apps

### Implementation Details :construction:
- Only links with `http` or `https` schemes can be opened by the browser. We check if the URL has one of these schemes, then we open it if it does. This prevents the browser from opening an invalid link and crashing the app.
- If a link has another scheme like `mailto` or `facetime`, we open it in the appropriate app
- If a link has no scheme, we append `https` and open it in the browser

### Testing Details :mag:
- Manual testing
