### PR TITLE
Point cartfile to latest binary

### DIFF
--- a/BoxPreviewSDKSampleApp/Cartfile
+++ b/BoxPreviewSDKSampleApp/Cartfile
@@ -2,7 +2,7 @@
 git "git@github.com:box/box-ios-browse-sdk.git" "master"
 git "git@github.com:box/box-ios-sdk.git" "objective-c-maintenance"
 
-binary "https://github.com/box/box-ios-preview-sdk/releases/download/v2.1.2/previewSDK.json" ==  2.1.2
+binary "https://github.com/box/box-ios-preview-sdk/releases/download/v2.2.0/previewSDK.json" ==  2.2.0
 
 # 3rd Party SDKs
 github "SnapKit/Masonry" ~> 1.0.1


### PR DESCRIPTION
The cartfile wasn't updated as part of the last release.  This change brings it current.