### PR TITLE
Select preview based on lower cased file extension

### DIFF
--- a/Sources/Core/UI/PreviewHelper.swift
+++ b/Sources/Core/UI/PreviewHelper.swift
@@ -19,7 +19,7 @@ internal class PreviewHelper {
     var fileName: String?
     var filePath: URL?
     var AVFileFormat = ["mp4", "mov", "wmv", "flv", "avi", "mp3"]
-    var otherFileFormat = ["pdf", "jpg", "jpeg", "png", "tiff", "tif", "gif", "bmp", "BMPf", "ico", "cur", "xbm"]
+    var otherFileFormat = ["pdf", "jpg", "jpeg", "png", "tiff", "tif", "gif", "bmp", "bmpf", "ico", "cur", "xbm"]
     var supportedFileFormat: [String] {
         return AVFileFormat + otherFileFormat
     }
@@ -54,7 +54,7 @@ internal class PreviewHelper {
             catch {
                 return .failure(BoxPreviewError(error: error))
             }
-        case "jpg", "jpeg", "png", "tiff", "tif", "gif", "bmp", "BMPf", "ico", "cur", "xbm":
+        case "jpg", "jpeg", "png", "tiff", "tif", "gif", "bmp", "bmpf", "ico", "cur", "xbm":
             do {
                 let data = try Data(contentsOf: unwrappedFileURL)
                 if let image = UIImage(data: data) {

--- a/Sources/Core/UI/PreviewHelper.swift
+++ b/Sources/Core/UI/PreviewHelper.swift
@@ -39,7 +39,7 @@ internal class PreviewHelper {
             return .failure(BoxPreviewError(message: .fileCouldNotBeDownloaded))
         }
         
-        switch unwrappedFileURL.pathExtension {
+        switch unwrappedFileURL.pathExtension.lowercased() {
         case "pdf":
             do {
                 let data = try Data(contentsOf: unwrappedFileURL)
@@ -102,7 +102,7 @@ internal class PreviewHelper {
             fileURL.appendPathComponent("master.m3u8")
             completion(self.processFileDownload(to: fileURL, result: .success(())))
         }
-        else if supportedFileFormat.contains(fileURL.pathExtension) {
+        else if supportedFileFormat.contains(fileURL.pathExtension.lowercased()) {
             self.client.files.download(
                 fileId: file.id,
                 destinationURL: fileURL,

--- a/Sources/Core/UI/PreviewViewController.swift
+++ b/Sources/Core/UI/PreviewViewController.swift
@@ -202,7 +202,7 @@ private extension PreviewViewController {
     }
     
     func previewFile(file: File) {
-        if let fileName = file.name, previewHelper.AVFileFormat.contains(URL(fileURLWithPath: fileName).pathExtension) {
+        if let fileName = file.name, previewHelper.AVFileFormat.contains(URL(fileURLWithPath: fileName).pathExtension.lowercased()) {
             self.client.files.listRepresentations(
                 fileId: file.id,
                 representationHint: .customValue("[hls]"),


### PR DESCRIPTION
### Issue Link :link:
Files with upper case extensions (as is common with JPEG files from cameras) fail to preview.

### Goals :soccer:
Lower case the file extension when selecting a preview, to handle more files.